### PR TITLE
fix: improve customer feedback for retrieve metadata

### DIFF
--- a/messages/retrieve.metadata.md
+++ b/messages/retrieve.metadata.md
@@ -113,7 +113,7 @@ Succeeded
 
 # Cancelled
 
-Cancelled
+Canceled
 
 # SucceededPartial
 

--- a/messages/retrieve.metadata.md
+++ b/messages/retrieve.metadata.md
@@ -97,7 +97,7 @@ If the command continues to run after the wait period, the CLI returns control o
 
 # RetrieveTitle
 
-Retrieving metadata
+Retrieving Metadata
 
 # Pending
 

--- a/messages/retrieve.metadata.md
+++ b/messages/retrieve.metadata.md
@@ -94,3 +94,35 @@ Number of minutes to wait for the command to complete and display results to the
 # flags.wait.description
 
 If the command continues to run after the wait period, the CLI returns control of the terminal window to you.
+
+# RetrieveTitle
+
+Retrieving metadata
+
+# Pending
+
+Pending
+
+# InProgress
+
+In Progress
+
+# Succeeded
+
+Succeeded
+
+# Cancelled
+
+Cancelled
+
+# SucceededPartial
+
+Partial Succeeded
+
+# Failed
+
+Failed
+
+# Canceling
+
+Canceling

--- a/messages/retrieve.metadata.md
+++ b/messages/retrieve.metadata.md
@@ -117,7 +117,7 @@ Canceled
 
 # SucceededPartial
 
-Partial Succeeded
+Partially Succeeded
 
 # Failed
 


### PR DESCRIPTION
### What does this PR do?
Adds a ux spinner that displays the status of the core service handling the retrieve.
### What issues does this PR fix or reference?
@W-9976770@

Displays spinner and current status of remote request

![Screen Shot 2021-10-01 at 2 42 07 PM](https://user-images.githubusercontent.com/17622511/135860707-cd38decb-cb9a-4989-9701-905202250cf2.png)

Displays final status of remote request upon completion

![Screen Shot 2021-10-01 at 2 42 29 PM](https://user-images.githubusercontent.com/17622511/135860727-fc050a02-c2b4-4675-b1d7-afaa26deae58.png)

